### PR TITLE
Sync the kubernetes-config-popup state with the state manager

### DIFF
--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -324,9 +324,15 @@
 (kubernetes-state--define-accessors label-query (label-name)
   (cl-assert (stringp label-name)))
 
-(kubernetes-state--define-accessors kubectl-flags (flags)
+(defun kubernetes-state-kubectl-flags (state)
+  (if-let (flags (alist-get 'kubectl-flags state))
+      flags
+    (alist-get 'kubectl-flags (kubernetes-state-update :update-kubectl-flags kubernetes-kubectl-flags))))
+
+(kubernetes-state--define-setter kubectl-flags (flags)
   (cl-assert (listp flags))
-  (cl-assert (-all? #'stringp flags)))
+  (cl-assert (-all? #'stringp flags))
+  (setq kubernetes-kubectl-flags flags))
 
 (kubernetes-state--define-getter marked-configmaps)
 (kubernetes-state--define-getter configmaps-pending-deletion)

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -35,6 +35,8 @@
        (setf (alist-get 'namespaces next) args))
       (:update-current-namespace
        (setf (alist-get 'current-namespace next) args))
+      (:update-kubectl-flags
+       (setf (alist-get 'kubectl-flags next) args))
 
       (:update-config
        (setf (alist-get 'config next) args)
@@ -318,6 +320,10 @@
 
 (kubernetes-state--define-accessors label-query (label-name)
   (cl-assert (stringp label-name)))
+
+(kubernetes-state--define-accessors kubectl-flags (flags)
+  (cl-assert (listp flags))
+  (cl-assert (--all? (stringp (car it)) flags)))
 
 (kubernetes-state--define-getter marked-configmaps)
 (kubernetes-state--define-getter configmaps-pending-deletion)

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -323,7 +323,7 @@
 
 (kubernetes-state--define-accessors kubectl-flags (flags)
   (cl-assert (listp flags))
-  (cl-assert (--all? (stringp (car it)) flags)))
+  (cl-assert (-all? #'stringp flags)))
 
 (kubernetes-state--define-getter marked-configmaps)
 (kubernetes-state--define-getter configmaps-pending-deletion)

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -65,6 +65,15 @@ balance interface stuttering with update frequency."
   :group 'kubernetes
   :type 'integer)
 
+(defcustom kubernetes-kubectl-flags nil
+  "A list of extra commandline flags to pass to kubectl.
+
+It is a list, where each element is assumed to be a flag of the
+form \"--flag=value\" or \"-flag\"."
+  :type '(repeat (string :tag "Argument"))
+  :group 'kubernetes)
+
+
 (defface kubernetes-context-name
   '((((class color) (background light)) :foreground "SkyBlue4")
     (((class color) (background  dark)) :foreground "LightSkyBlue1"))
@@ -139,6 +148,7 @@ balance interface stuttering with update frequency."
 
 (defvar kubernetes-redraw-hook nil
   "Hook run every time redrawing should occur.")
+
 
 
 (provide 'kubernetes-vars)

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -128,7 +128,7 @@
   (kubernetes-state-update-config sample-get-config-response))
 
 (kubernetes-state-test-accessor kubectl-flags
-  (kubernetes-state-update-kubectl-flags '(("--key=" . value))))
+  (kubernetes-state-update-kubectl-flags '("--key=value")))
 
 (ert-deftest kubernetes-state-test--error-is-alist ()
   (test-helper-with-empty-state

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -159,6 +159,21 @@
     (should (kubernetes-state-config (kubernetes-state)))
     (should (equal "foo" (kubernetes-state-current-namespace (kubernetes-state))))))
 
+(ert-deftest kubernetes-state-test--kubectl-flags-initialized-using-config-popup-vars ()
+  (let ((kubernetes-kubectl-flags '("--foo=bar" "-x")))
+    (should (equal kubernetes-kubectl-flags (kubernetes-state-kubectl-flags nil)))))
+
+(ert-deftest kubernetes-state-test--kubectl-flags-not-reinitialized-if-present ()
+  (let ((flags '("--foo=bar" "-x")))
+    (test-helper-with-empty-state
+      (kubernetes-state-update-kubectl-flags flags)
+      (should (equal flags (kubernetes-state-kubectl-flags (kubernetes-state)))))))
+
+(ert-deftest kubernetes-state-test--updating-kubectl-flags-updates-global-variable ()
+  (let ((flags '("--foo=bar" "-x")))
+    (test-helper-with-empty-state
+      (kubernetes-state-update-kubectl-flags flags)
+      (should (equal kubernetes-kubectl-flags flags)))))
 
 ;; Test marking/unmarking/deleting actions
 

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -127,6 +127,9 @@
 (kubernetes-state-test-accessor config
   (kubernetes-state-update-config sample-get-config-response))
 
+(kubernetes-state-test-accessor kubectl-flags
+  (kubernetes-state-update-kubectl-flags '(("--key=" . value))))
+
 (ert-deftest kubernetes-state-test--error-is-alist ()
   (test-helper-with-empty-state
     (let ((time (current-time)))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -46,7 +46,8 @@
 
 (defmacro test-helper-with-empty-state (&rest body)
   (declare (indent 0))
-  `(let ((kubernetes-state--current-state nil))
+  `(let ((kubernetes-state--current-state nil)
+         (kubernetes-kubectl-flags))
      ,@body))
 
 


### PR DESCRIPTION
Adds a number of useful settings to the config popup, and keeps magit's global variables in sync with the application state.

Resolves #4.