### PR TITLE
Make overview customisable

### DIFF
--- a/kubernetes-evil.el
+++ b/kubernetes-evil.el
@@ -70,6 +70,9 @@
   (kbd "l") #'kubernetes-logs-popup
   (kbd "L") #'kubernetes-labels-popup)
 
+(evil-define-key 'motion kubernetes-overview-mode-map
+  (kbd "v") #'kubernetes-overview-set-sections)
+
 (evil-define-key 'motion kubernetes-logs-mode-map
   (kbd "n") #'kubernetes-logs-forward-line
   (kbd "p") #'kubernetes-logs-previous-line

--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -22,14 +22,21 @@
 ;; Component
 
 (defun kubernetes-overview-render (state)
-  `(section (root nil)
-            ,(kubernetes-errors-render state)
-            ,(kubernetes-contexts-render state)
-            ,(kubernetes-configmaps-render state t)
-            ,(kubernetes-deployments-render state t)
-            ,(kubernetes-pods-render state t)
-            ,(kubernetes-secrets-render state t)
-            ,(kubernetes-services-render state t)))
+  (let ((sections (kubernetes-state-overview-sections state)))
+    `(section (root nil)
+              ,(kubernetes-errors-render state)
+              ,(when (member 'context sections)
+                 (kubernetes-contexts-render state))
+              ,(when (member 'configmaps sections)
+                 (kubernetes-configmaps-render state))
+              ,(when (member 'deployments sections)
+                 (kubernetes-deployments-render state))
+              ,(when (member 'pods sections)
+                 (kubernetes-pods-render state))
+              ,(when (member 'secrets sections)
+                 (kubernetes-secrets-render state))
+              ,(when (member 'services sections)
+                 (kubernetes-services-render state)))))
 
 
 ;; Overview buffer.

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -37,6 +37,8 @@
        (setf (alist-get 'current-namespace next) args))
       (:update-kubectl-flags
        (setf (alist-get 'kubectl-flags next) args))
+      (:update-overview-sections
+       (setf (alist-get 'overview-sections next) args))
 
       (:update-config
        (setf (alist-get 'config next) args)
@@ -323,6 +325,22 @@
 
 (kubernetes-state--define-accessors label-query (label-name)
   (cl-assert (stringp label-name)))
+
+(defun kubernetes-state-overview-sections (state)
+  (or (alist-get 'overview-sections state)
+      (let* ((configurations (append kubernetes-overview-custom-views-alist kubernetes-overview-views-alist))
+             (sections (alist-get kubernetes-default-overview-view configurations))
+             (updated (kubernetes-state-update :update-overview-sections sections)))
+        (alist-get 'overview-sections updated))))
+
+(kubernetes-state--define-setter overview-sections (resources)
+  (cl-assert (--all? (member it '(context
+                                  configmaps
+                                  deployments
+                                  pods
+                                  secrets
+                                  services))
+                     resources)))
 
 (defun kubernetes-state-kubectl-flags (state)
   (if-let (flags (alist-get 'kubectl-flags state))

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -343,9 +343,9 @@
                      resources)))
 
 (defun kubernetes-state-kubectl-flags (state)
-  (if-let (flags (alist-get 'kubectl-flags state))
-      flags
-    (alist-get 'kubectl-flags (kubernetes-state-update :update-kubectl-flags kubernetes-kubectl-flags))))
+  (or (alist-get 'kubectl-flags state)
+      (let ((updated (kubernetes-state-update :update-kubectl-flags kubernetes-kubectl-flags)))
+        (alist-get 'kubectl-flags updated))))
 
 (kubernetes-state--define-setter kubectl-flags (flags)
   (cl-assert (listp flags))

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -12,6 +12,43 @@
   :group 'kubernetes
   :type 'string)
 
+(defconst kubernetes-overview-views-alist
+  '((all . (context configmaps deployments pods secrets services))
+    (configmaps . (context configmaps))
+    (deployments . (context deployments))
+    (pods . (context pods))
+    (secrets . (context secrets))
+    (services . (context services)))
+  "Enumerates the different views that can be displayed in the overview.
+
+Each element is a cons-cell of the form (SYMBOL . LIST), where
+SYMBOL is a name for the view, and LIST is a list of resource
+types that should be displayed.")
+
+(defcustom kubernetes-overview-custom-views-alist nil
+  "Enumerates the different views that can be displayed in the overview.
+
+Each element is a cons-cell of the form (SYMBOL . LIST), where
+SYMBOL is a name for the view, and LIST is a list of resource
+types that should be displayed."
+  :group 'kubernetes
+  :type '(alist :key-type symbol
+                :value-type (set (const context)
+                                 (const configmaps)
+                                 (const deployments)
+                                 (const pods)
+                                 (const secrets)
+                                 (const services))))
+
+(defcustom kubernetes-default-overview-view 'deployments
+  "The view to use when first opening the overview.
+
+It should be one of the keys defined in
+`kubernetes-overview-views-alist' or
+`kubernetes-overview-custom-views-alist'."
+  :group 'kubernetes
+  :type 'symbol)
+
 (defcustom kubernetes-commands-display-buffer-select t
   "Whether to select Kubernetes buffers automatically."
   :group 'kubernetes

--- a/test/kubernetes-overview-test.el
+++ b/test/kubernetes-overview-test.el
@@ -1,0 +1,25 @@
+;;; kubernetes-overview-test.el --- Tests for kubernetes-overview.el  -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(require 'kubernetes-overview)
+
+
+;; Uses state to determine which sections to draw
+
+(ert-deftest kubernetes-overview-test--renders-selected-sections-from-state ()
+  (test-helper-with-empty-state
+    (kubernetes-state-update-overview-sections '(configmaps secrets))
+    (kubernetes-ast-eval (kubernetes-overview-render (kubernetes-state)))
+
+    (let ((expected (with-temp-buffer
+                      (kubernetes-ast-eval `(section (root nil)
+                                                     ,(kubernetes-errors-render (kubernetes-state))
+                                                     ,(kubernetes-configmaps-render (kubernetes-state))
+                                                     ,(kubernetes-secrets-render (kubernetes-state))))
+                      (substring-no-properties (buffer-string)))))
+      (should (equal expected (substring-no-properties (buffer-string)))))))
+
+(provide 'kubernetes-overview-test)
+
+;;; kubernetes-overview-test.el ends here

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -130,6 +130,9 @@
 (kubernetes-state-test-accessor kubectl-flags
   (kubernetes-state-update-kubectl-flags '("--key=value")))
 
+(kubernetes-state-test-accessor overview-sections
+  (kubernetes-state-update-overview-sections '(configmaps)))
+
 (ert-deftest kubernetes-state-test--error-is-alist ()
   (test-helper-with-empty-state
     (let ((time (current-time)))
@@ -174,6 +177,18 @@
     (test-helper-with-empty-state
       (kubernetes-state-update-kubectl-flags flags)
       (should (equal kubernetes-kubectl-flags flags)))))
+
+(ert-deftest kubernetes-state-test--overview-sections-initialized-using-default-view-variable ()
+  (let ((kubernetes-default-overview-view 'configmaps))
+    (test-helper-with-empty-state
+      (should (equal '(context configmaps) (kubernetes-state-overview-sections nil))))))
+
+(ert-deftest kubernetes-state-test--overview-sections-not-reinitialized-if-present ()
+  (let ((sections '(context)))
+    (test-helper-with-empty-state
+      (kubernetes-state-update-overview-sections sections)
+      (should (equal sections (kubernetes-state-overview-sections (kubernetes-state)))))))
+
 
 ;; Test marking/unmarking/deleting actions
 


### PR DESCRIPTION
- Allows users to choose which resources are displayed in the overview. 
- Shows only deployments by default 
- Adds a key binding to switch between the default set of resources (`v` by default)