### PR TITLE
Add --container option to kubernetes-logs-popup

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -126,7 +126,7 @@
 (defun kubernetes-copy-thing-at-point (point)
   "Perform a context-sensitive copy action.
 
-Inspecs the `kubernetes-copy' text property at POINT to determine
+Inspects the `kubernetes-copy' text property at POINT to determine
 what to copy."
   (interactive "d")
   (when-let (s (get-text-property point 'kubernetes-copy))

--- a/kubernetes-popups.el
+++ b/kubernetes-popups.el
@@ -32,6 +32,7 @@
   :options
   '("Options for customizing logging behaviour"
     (?t "Number of lines to display" "--tail=" read-number)
+    (?c "Container to read logs from" "--container=" kubernetes-utils-read-container-name)
     "Time controls"
     (?s "Since relative time" "--since=" kubernetes-utils-read-time-value)
     (?d "Since absolute datetime" "--since-time=" kubernetes-utils-read-iso-datetime))

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -59,9 +59,11 @@ Update the pod state if it not set yet."
     result))
 
 (defun kubernetes-utils-maybe-pod-name-at-point ()
-  (pcase (get-text-property (point) 'kubernetes-nav)
-    (`(:pod-name ,value)
-     value)))
+  (let ((nav-buffer (get-buffer kubernetes-overview-buffer-name)))
+    (with-current-buffer nav-buffer
+      (pcase (get-text-property (point) 'kubernetes-nav nav-buffer)
+        (`(:pod-name ,value)
+         value)))))
 
 (defun kubernetes-utils-ellipsize (s threshold)
   (if (> (length s) threshold)

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -42,6 +42,10 @@ Update the pod state if it not set yet."
                                "\\1:\\2"
                                tz))))
 
+(defun kubernetes-utils-read-container-name (&rest _)
+  "Read a container name to pass to kubectl."
+  (read-string "Container name: "))
+
 (defun kubernetes-utils-read-time-value (&rest _)
   "Read a relative time value in the style accepted by kubectl.  E.g. 20s, 3h, 5m."
   (let (result)


### PR DESCRIPTION
This adds a `=c` option to the `kubernetes-logs-popup` which can be used to select the container to read logs from.

This implementation doesn't make use of the `kubernetes-state` (yet) to display the correct containers, but it is an improvement over the current situation where all you can get is a `kubectl`-error. If I find the time I'll try to add container selection, too.

Fixes #66.