### PR TITLE
Replace deprecated call to magit-section-content

### DIFF
--- a/kubernetes-ast.el
+++ b/kubernetes-ast.el
@@ -115,7 +115,7 @@ such in rendering ASTs." name)))
     (insert ?\n))
 
   ;; Update containing section to point to this heading.
-  (setf (magit-section-content magit-insert-section--current) (point-marker)))
+  (setf (oref magit-insert-section--current content) (point-marker)))
 
 (defsubst kubernetes-ast--finalize-delete-marks (start-pos)
   (let ((end-line (line-number-at-pos)))


### PR DESCRIPTION
Magit removed the function magit-section-content in commit: https://github.com/magit/magit/commit/3f3bc14f
It's not in a release yet.

It breaks the kubernetes overview display. 

This pull request fixes that.