### PR TITLE
Adding the all the flags to the command which adds the --kubeconfig if present

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -259,7 +259,7 @@ Should be invoked via command `kubernetes-logs-popup'."
                          (if (string-empty-p cmd) kubernetes-default-exec-command cmd))))
                  (list pod-name (kubernetes-exec-arguments) command state)))
 
-  (let* ((command-args (append (list "exec")
+  (let* ((command-args (append (list "exec") (kubernetes-kubectl--flags-from-state (kubernetes-state))
                                args
                                (when-let (ns (kubernetes-state-current-namespace state))
                                  (list (format "--namespace=%s" ns)))

--- a/kubernetes-logs.el
+++ b/kubernetes-logs.el
@@ -88,7 +88,7 @@ STATE is the current application state"
      (list (or (kubernetes-utils-maybe-pod-name-at-point) (kubernetes-utils-read-pod-name state))
            (kubernetes-logs-arguments)
            state)))
-  (let ((args (append (list "logs") args (list pod-name)
+  (let ((args (append (list "logs") args (list pod-name) (kubernetes-kubectl--flags-from-state (kubernetes-state))
                       (when-let (ns (kubernetes-state-current-namespace state))
                         (list (format "--namespace=%s" ns))))))
     (with-current-buffer (kubernetes-utils-process-buffer-start kubernetes-logs-buffer-name #'kubernetes-logs-mode kubernetes-kubectl-executable args)


### PR DESCRIPTION
Fix for #73 #64 . Added all the flags to the end of the logs command which fixes the --kubeconfig missing problem.