### PR TITLE
Add explicit dependency on magit-popup

### DIFF
--- a/kubernetes.el
+++ b/kubernetes.el
@@ -6,7 +6,7 @@
 
 ;; Version: 0.12.0
 
-;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit "2.8.0"))
+;; Package-Requires: ((emacs "25.1") (dash "2.12.0") (magit "2.8.0") (magit-popup "2.13.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
magit switched to using transient[1] for providing popups. As a result,
magit-popup will no longer be installed as a dependency of magit and
must be explicitly required.

[1] https://github.com/magit/transient