### PR TITLE
Fix call to "kubectl get pods"

### DIFF
--- a/kubernetes-kubectl.el
+++ b/kubernetes-kubectl.el
@@ -97,7 +97,7 @@ PROPS is an alist of functions to inject.  It should normally be passed
 STATE is the application state.
 
 CLEANUP-CB is a function taking no arguments used to release any resources."
-  (kubernetes-kubectl props state '("get" "pods" "--show-all" "-o" "json")
+  (kubernetes-kubectl props state '("get" "pods" "-o" "json")
                       (lambda (buf)
                         (let ((json (with-current-buffer buf
                                       (json-read-from-string (buffer-string)))))

--- a/test/kubernetes-kubectl-test.el
+++ b/test/kubernetes-kubectl-test.el
@@ -108,7 +108,7 @@ will be mocked."
          (parsed-response (json-read-from-string sample-response))
          (cleanup-callback-called))
 
-    (with-successful-response-at '("get" "pods" "--show-all" "-o" "json") sample-response
+    (with-successful-response-at '("get" "pods" "-o" "json") sample-response
       (kubernetes-kubectl-get-pods
        kubernetes-kubectl-test-props
        nil


### PR DESCRIPTION
--show-all is no longer a valid argument

See: kubernetes/kubernetes#69255