### PR TITLE
Implement setting for namespace on running kubernetes-overview

### DIFF
--- a/kubernetes-overview.el
+++ b/kubernetes-overview.el
@@ -352,6 +352,9 @@ Type \\[kubernetes-refresh] to refresh the buffer.
   (interactive)
   (let ((dir default-directory)
         (buf (kubernetes-overview--initialize-buffer)))
+    (when kubernetes-default-overview-namespace
+      (kubernetes-set-namespace kubernetes-default-overview-namespace
+				(kubernetes-state)))
     (kubernetes-commands-display-buffer buf)
     (with-current-buffer buf
       (cd (kubernetes-utils-up-to-existing-dir dir)))

--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -51,6 +51,12 @@ It should be one of the keys defined in
   :group 'kubernetes
   :type 'symbol)
 
+(defcustom kubernetes-default-overview-namespace nil
+  "The Kubernetes namespace to select on `kubernetes-overview'.
+Uses the default namespace if nil."
+  :group 'kubernetes
+  :type 'string)
+
 (defcustom kubernetes-commands-display-buffer-select t
   "Whether to select Kubernetes buffers automatically."
   :group 'kubernetes


### PR DESCRIPTION
I often do not have access to list all namespaces in a k8s context.
I've implemented a new `kubernetes-default-overview-namespace` variable to select a namespace when `kubernetes-overview` is called.

More than happy to make any changes! :smile_cat: 