### PR TITLE
Set namespace on switching context

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -348,11 +348,16 @@ CONTEXT is the name of a context as a string."
     (with-current-buffer buf
       (goto-char (point-min))))
 
-  (kubernetes-kubectl-config-use-context kubernetes-props
-                                         (kubernetes-state)
-                                         context
-                                         (lambda (_)
-                                           (kubernetes-state-trigger-redraw))))
+  (let ((state (kubernetes-state)))
+    (kubernetes-kubectl-config-use-context
+     kubernetes-props
+     state
+     context
+     (lambda (_)
+       (when kubernetes-default-overview-namespace
+         (kubernetes-set-namespace kubernetes-default-overview-namespace
+                                   state))
+       (kubernetes-state-trigger-redraw)))))
 
 (defun kubernetes--context-names (state)
   (-let* ((config (or (kubernetes-state-config state) (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-config-view)))


### PR DESCRIPTION
I noticed that the namespace is reset to `default` on switching context.
If the default namespace has been customized, it should be used instead.

Related to #104.

More than happy to make any changes! 