### PR TITLE
Remove redisplay function customizations from `kubernetes-mode`

### DIFF
--- a/kubernetes-modes.el
+++ b/kubernetes-modes.el
@@ -79,8 +79,6 @@
   (push (cons 'kubernetes-nav t) text-property-default-nonsticky)
   (push (cons 'kubernetes-copy t) text-property-default-nonsticky)
   (add-hook 'post-command-hook #'magit-section-update-highlight t t)
-  (setq-local redisplay-highlight-region-function 'magit-highlight-region)
-  (setq-local redisplay-unhighlight-region-function 'magit-unhighlight-region)
   (when (bound-and-true-p global-linum-mode)
     (linum-mode -1))
   (when (and (fboundp 'nlinum-mode)


### PR DESCRIPTION
The redisplay function customizations in `kubernetes-mode` use magit's
`magit-{un,}highlight-region` functions, which were recently renamed
in magit/magit@e4b6497.

Instead of updating `kubernetes-mode` to use the new function names,
let's remove the redisplay function customizations altogether: magit's
functions seem to only handle edge cases of sections with diff hunks
in them, which are not used in this package.

See https://github.com/chrisbarrett/kubernetes-el/issues/116