### PR TITLE
Fix pod display failures when containerStatus is missing in the

### DIFF
--- a/test/kubernetes-pods-test.el
+++ b/test/kubernetes-pods-test.el
@@ -61,10 +61,10 @@ Pods (0)
 (defconst kubernetes-pods-test--sample-result
   (s-trim-left "
 
-Pods (2)
+Pods (3)
   Name                                          Status     Ready   Restarts    Age
   example-svc-v3-1603416598-2f9lb               Running      1/1        0      36d
-    Name:       example-service
+    Name:       example-service-2
     Label:      example-pod-v3
     Namespace:  ns.example
     Image:      example.com/example-service:3.0.0
@@ -73,10 +73,19 @@ Pods (2)
     Started:    2017-02-25T08:12:14Z
 
   example-svc-v4-1603416598-2f9lb               Running      1/1        0      36d
-    Name:       example-service
+    Name:       example-service-4
     Label:      example-pod-v4
     Namespace:  ns.example
     Image:      example.com/example-service:4.8.0
+    Host IP:    10.0.0.0
+    Pod IP:     172.0.0.1
+    Started:    2017-02-25T08:12:14Z
+
+  example-svc-v5-1603416598-2f9lb               Running      0/0        0      36d
+    Name:       N/A
+    Label:      example-pod-v5
+    Namespace:  ns.example
+    Image:      N/A
     Host IP:    10.0.0.0
     Pod IP:     172.0.0.1
     Started:    2017-02-25T08:12:14Z
@@ -92,6 +101,7 @@ Pods (2)
                         (draw-pods-section state)))
       (should (equal kubernetes-pods-test--sample-result
                      (substring-no-properties (buffer-string)))))))
+
 
 (ert-deftest kubernetes-pods-test--sample-response-text-properties ()
   (let ((state `((pods . ,sample-get-pods-response)

--- a/test/resources/get-pods-response.json
+++ b/test/resources/get-pods-response.json
@@ -79,7 +79,7 @@
               "successThreshold": 1,
               "timeoutSeconds": 3
             },
-            "name": "example-service",
+            "name": "example-service-1",
             "ports": [
               {
                 "containerPort": 9000,
@@ -185,7 +185,7 @@
             "image": "example.com/example-service:3.0.0",
             "imageID": "docker-pullable://example.com/example-service@sha256:2406309063027f398037b69c3cfcb2e108213f45c47998d26eedaf16d8253871",
             "lastState": {},
-            "name": "example-service",
+            "name": "example-service-2",
             "ready": true,
             "restartCount": 0,
             "state": {
@@ -279,7 +279,7 @@
               "successThreshold": 1,
               "timeoutSeconds": 3
             },
-            "name": "example-service",
+            "name": "example-service-3",
             "ports": [
               {
                 "containerPort": 9000,
@@ -385,7 +385,7 @@
             "image": "example.com/example-service:4.8.0",
             "imageID": "docker-pullable://example.com/example-service@sha256:2406309063027f398037b69c3cfcb2e108213f45c47998d26eedaf16d8253871",
             "lastState": {},
-            "name": "example-service",
+            "name": "example-service-4",
             "ready": true,
             "restartCount": 0,
             "state": {
@@ -400,7 +400,193 @@
         "podIP": "172.0.0.1",
         "startTime": "2017-02-25T08:12:14Z"
       }
+    },
+        {
+      "apiVersion": "v1",
+      "kind": "Pod",
+      "metadata": {
+        "annotations": {
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"ns.example\",\"name\":\"example-svc-v5-1603416598\",\"uid\":\"1d81f2b3-fb32-11e6-98d0-eae012fc8e71\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"62687065\"}}\n"
+        },
+        "creationTimestamp": "2017-02-25T08:12:14Z",
+        "generateName": "example-svc-v5-1603416598-",
+        "labels": {
+          "name": "example-pod-v5",
+          "pod-template-hash": "1603416598"
+        },
+        "name": "example-svc-v5-1603416598-2f9lb",
+        "namespace": "ns.example",
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "controller": true,
+            "kind": "ReplicaSet",
+            "name": "example-svc-v5-1603416598",
+            "uid": "1d81f2b3-fb32-11e6-98d0-eae012fc8e71"
+          }
+        ],
+        "resourceVersion": "62687662",
+        "selfLink": "/api/v1/namespaces/ns.example/pods/example-svc-v5-1603416598-2f9lb",
+        "uid": "1d85a702-fb32-11e6-8378-0e9fa26c327b"
+      },
+      "spec": {
+        "containers": [
+          {
+            "env": [
+              {
+                "name": "EXAMPLE_VAR_1",
+                "value": "value1"
+              },
+              {
+                "name": "ES_EXAMPLE_VAR_2",
+                "valueFrom": {
+                  "configMapKeyRef": {
+                    "key": "var2",
+                    "name": "app-config"
+                  }
+                }
+              },
+              {
+                "name": "EXAMPLE_SECRET_1",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "key": "secret1",
+                    "name": "app-secret"
+                  }
+                }
+              },
+              {
+                "name": "EXAMPLE_SECRET_2",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "key": "secret2",
+                    "name": "app-secret"
+                  }
+                }
+              }
+            ],
+            "image": "example.com/example-service:4.8.0",
+            "imagePullPolicy": "IfNotPresent",
+            "livenessProbe": {
+              "failureThreshold": 3,
+              "httpGet": {
+                "path": "/liveness",
+                "port": 9000,
+                "scheme": "HTTP"
+              },
+              "initialDelaySeconds": 90,
+              "periodSeconds": 10,
+              "successThreshold": 1,
+              "timeoutSeconds": 3
+            },
+            "name": "example-service-5",
+            "ports": [
+              {
+                "containerPort": 9000,
+                "name": "http",
+                "protocol": "TCP"
+              }
+            ],
+            "resources": {
+              "limits": {
+                "cpu": "400m",
+                "memory": "400Mi"
+              },
+              "requests": {
+                "cpu": "50m",
+                "memory": "400Mi"
+              }
+            },
+            "terminationMessagePath": "/dev/termination-log",
+            "volumeMounts": [
+              {
+                "mountPath": "/app/mnt",
+                "name": "app-config"
+              },
+              {
+                "mountPath": "/app/mnt2",
+                "name": "auth-config"
+              },
+              {
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                "name": "default-token-vnequ",
+                "readOnly": true
+              }
+            ]
+          }
+        ],
+        "dnsPolicy": "ClusterFirst",
+        "nodeName": "ip-10-0-0-0.ec2.internal",
+        "restartPolicy": "Always",
+        "securityContext": {},
+        "serviceAccount": "default",
+        "serviceAccountName": "default",
+        "terminationGracePeriodSeconds": 30,
+        "volumes": [
+          {
+            "configMap": {
+              "defaultMode": 420,
+              "items": [
+                {
+                  "key": "application.conf",
+                  "path": "application.conf"
+                }
+              ],
+              "name": "app-config"
+            },
+            "name": "app-config"
+          },
+          {
+            "configMap": {
+              "defaultMode": 420,
+              "items": [
+                {
+                  "key": "auth.conf",
+                  "path": "auth.conf"
+                }
+              ],
+              "name": "auth-config"
+            },
+            "name": "auth-config"
+          },
+          {
+            "name": "default-token-vnequ",
+            "secret": {
+              "defaultMode": 420,
+              "secretName": "default-token-vnequ"
+            }
+          }
+        ]
+      },
+      "status": {
+        "conditions": [
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-25T08:12:14Z",
+            "status": "True",
+            "type": "Initialized"
+          },
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-25T08:13:39Z",
+            "status": "True",
+            "type": "Ready"
+          },
+          {
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-25T08:12:14Z",
+            "status": "True",
+            "type": "PodScheduled"
+          }
+        ],
+
+        "hostIP": "10.0.0.0",
+        "phase": "Running",
+        "podIP": "172.0.0.1",
+        "startTime": "2017-02-25T08:12:14Z"
+      }
     }
+
   ],
   "kind": "List",
   "metadata": {},


### PR DESCRIPTION
Handles the containers that did not launch, previously if the container did not have a status the pod screen would not render because it failed on looking up non existent keys, now checks and provides defaults when containerrStatuses is missing in the response json.

I struggled with this quite a bit, not much info on dash.el other than the official docs which I struggled with so there may be better ways.

fixes #113