### PR TITLE
Synchronous `kubernetes-*resource*-refresh-now`

### DIFF
--- a/kubernetes-configmaps.el
+++ b/kubernetes-configmaps.el
@@ -81,17 +81,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-configmaps-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-configmaps-process-live-p)
-    (kubernetes-process-set-poll-configmaps-process
-     (kubernetes-kubectl-get-configmaps kubernetes-props
-                                        (kubernetes-state)
-                                        (lambda (response)
-                                          (kubernetes-state-update-configmaps response)
-                                          (when interactive
-                                            (message "Updated configmaps.")))
-                                        (lambda ()
-                                          (kubernetes-process-release-poll-configmaps-process))))))
+(kubernetes-state-define-refreshers configmaps)
 
 (defun kubernetes-configmaps-delete-marked (state)
   (let ((names (kubernetes-state-marked-configmaps state)))

--- a/kubernetes-contexts.el
+++ b/kubernetes-contexts.el
@@ -64,6 +64,8 @@
 
 (defalias 'kubernetes-contexts-refresh-now 'kubernetes-config-refresh-now)
 (defalias 'kubernetes-contexts-refresh 'kubernetes-config-refresh-now)
+(defalias 'kubernetes-state-contexts 'kubernetes-state-config)
+(defalias 'kubernetes-state-update-contexts 'kubernetes-state-update-config)
 
 ;; Displaying config.
 

--- a/kubernetes-contexts.el
+++ b/kubernetes-contexts.el
@@ -59,18 +59,11 @@
 
 ;; Requests and state management
 
-(defun kubernetes-contexts-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-config-process-live-p)
-    (kubernetes-process-set-poll-config-process
-     (kubernetes-kubectl-config-view kubernetes-props
-                                     (kubernetes-state)
-                                     (lambda (response)
-                                       (kubernetes-state-update-config response)
-                                       (when interactive
-                                         (message "Updated config.")))
-                                     (lambda ()
-                                       (kubernetes-process-release-poll-config-process))))))
+(kubernetes-state-define-refreshers config kubernetes-kubectl-config-view
+  "config view -o json")
 
+(defalias 'kubernetes-contexts-refresh-now 'kubernetes-config-refresh-now)
+(defalias 'kubernetes-contexts-refresh 'kubernetes-config-refresh-now)
 
 ;; Displaying config.
 

--- a/kubernetes-deployments.el
+++ b/kubernetes-deployments.el
@@ -140,17 +140,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-deployments-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-deployments-process-live-p)
-    (kubernetes-process-set-poll-deployments-process
-     (kubernetes-kubectl-get-deployments kubernetes-props
-                                         (kubernetes-state)
-                                         (lambda (response)
-                                           (kubernetes-state-update-deployments response)
-                                           (when interactive
-                                             (message "Updated deployments.")))
-                                         (lambda ()
-                                           (kubernetes-process-release-poll-deployments-process))))))
+(kubernetes-state-define-refreshers deployments)
 
 (defun kubernetes-deployments-delete-marked (state)
   (let ((names (kubernetes-state-marked-deployments state)))

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -83,17 +83,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-ingress-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-ingress-process-live-p)
-    (kubernetes-process-set-poll-ingress-process
-     (kubernetes-kubectl-get-ingress kubernetes-props
-                                     (kubernetes-state)
-                                     (lambda (response)
-                                       (kubernetes-state-update-ingress response)
-                                       (when interactive
-                                         (message "Updated ingress.")))
-                                     (lambda ()
-                                       (kubernetes-process-release-poll-ingress-process))))))
+(kubernetes-state-define-refreshers ingress)
 
 
 

--- a/kubernetes-ingress.el
+++ b/kubernetes-ingress.el
@@ -85,8 +85,6 @@
 
 (kubernetes-state-define-refreshers ingress)
 
-
-
 (defun kubernetes-ingress-delete-marked (state)
   (let ((names (kubernetes-state-marked-ingress state)))
     (dolist (name names)

--- a/kubernetes-jobs.el
+++ b/kubernetes-jobs.el
@@ -125,17 +125,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-jobs-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-jobs-process-live-p)
-    (kubernetes-process-set-poll-jobs-process
-     (kubernetes-kubectl-get-jobs kubernetes-props
-                                  (kubernetes-state)
-                                  (lambda (response)
-                                    (kubernetes-state-update-jobs response)
-                                    (when interactive
-                                      (message "Updated jobs.")))
-                                  (lambda ()
-                                    (kubernetes-process-release-poll-jobs-process))))))
+(kubernetes-state-define-refreshers jobs)
 
 (defun kubernetes-jobs-delete-marked (state)
   (let ((names (kubernetes-state-marked-jobs state)))

--- a/kubernetes-namespaces.el
+++ b/kubernetes-namespaces.el
@@ -11,18 +11,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-namespaces-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-namespaces-process-live-p)
-    (kubernetes-process-set-poll-namespaces-process
-     (kubernetes-kubectl-get-namespaces kubernetes-props
-                                        (kubernetes-state)
-                                        (lambda (response)
-                                          (kubernetes-state-update-namespaces response)
-                                          (when interactive
-                                            (message "Updated namespaces.")))
-                                        (lambda ()
-                                          (kubernetes-process-release-poll-namespaces-process))))))
-
+(kubernetes-state-define-refreshers namespaces)
 
 ;; Displaying namespaces
 

--- a/kubernetes-nodes.el
+++ b/kubernetes-nodes.el
@@ -112,17 +112,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-nodes-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-nodes-process-live-p)
-    (kubernetes-process-set-poll-nodes-process
-     (kubernetes-kubectl-get-nodes kubernetes-props
-                                  (kubernetes-state)
-                                  (lambda (response)
-                                    (kubernetes-state-update-nodes response)
-                                    (when interactive
-                                      (message "Updated nodes.")))
-                                  (lambda ()
-                                    (kubernetes-process-release-poll-nodes-process))))))
+(kubernetes-state-define-refreshers nodes)
 
 ;; Interactive commands
 
@@ -136,7 +126,9 @@ Update the node state if it not set yet."
            (or (kubernetes-state-nodes state)
                (progn
                  (message "Getting nodes...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-nodes)))
+                 (let ((response (kubernetes-kubectl-await-on-async
+                                  kubernetes-props state
+                                  #'kubernetes-kubectl-get-nodes)))
                    (kubernetes-state-update-nodes response)
                    response))))
           (nodes (append nodes nil))

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -144,17 +144,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-pods-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-pods-process-live-p)
-    (kubernetes-process-set-poll-pods-process
-     (kubernetes-kubectl-get-pods kubernetes-props
-                                  (kubernetes-state)
-                                  (lambda (response)
-                                    (kubernetes-state-update-pods response)
-                                    (when interactive
-                                      (message "Updated pods.")))
-                                  (lambda ()
-                                    (kubernetes-process-release-poll-pods-process))))))
+(kubernetes-state-define-refreshers pods)
 
 (defun kubernetes-pods-delete-marked (state)
   (let ((names (kubernetes-state-marked-pods state)))

--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -146,6 +146,25 @@
 
 (kubernetes-state-define-refreshers pods)
 
+;; Displaying pods
+
+(defun kubernetes-pods--read-name (state)
+  "Read a pod name from the user.
+
+STATE is the current application state.
+
+Update the pod state if it not set yet."
+  (-let* (((&alist 'items pods)
+           (or (kubernetes-state-pods state)
+               (progn
+                 (message "Getting pods...")
+                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-pods)))
+                   (kubernetes-state-update-pods response)
+                   response))))
+          (pods (append pods nil))
+          (names (-map #'kubernetes-state-resource-name pods)))
+    (completing-read "Pod: " names nil t)))
+
 (defun kubernetes-pods-delete-marked (state)
   (let ((names (kubernetes-state-marked-pods state)))
     (dolist (name names)

--- a/kubernetes-secrets.el
+++ b/kubernetes-secrets.el
@@ -78,17 +78,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-secrets-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-secrets-process-live-p)
-    (kubernetes-process-set-poll-secrets-process
-     (kubernetes-kubectl-get-secrets kubernetes-props
-                                     (kubernetes-state)
-                                     (lambda (response)
-                                       (kubernetes-state-update-secrets response)
-                                       (when interactive
-                                         (message "Updated secrets.")))
-                                     (lambda ()
-                                       (kubernetes-process-release-poll-secrets-process))))))
+(kubernetes-state-define-refreshers secrets)
 
 (defun kubernetes-secrets-delete-marked (state)
   (let ((names (kubernetes-state-marked-secrets state)))

--- a/kubernetes-services.el
+++ b/kubernetes-services.el
@@ -113,17 +113,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-services-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-services-process-live-p)
-    (kubernetes-process-set-poll-services-process
-     (kubernetes-kubectl-get-services kubernetes-props
-                                      (kubernetes-state)
-                                      (lambda (response)
-                                        (kubernetes-state-update-services response)
-                                        (when interactive
-                                          (message "Updated services.")))
-                                      (lambda ()
-                                        (kubernetes-process-release-poll-services-process))))))
+(kubernetes-state-define-refreshers services)
 
 (defun kubernetes-services-delete-marked (state)
   (let ((names (kubernetes-state-marked-services state)))

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -409,6 +409,7 @@
              (function
               ,(intern (format "kubernetes-process-release-poll-%s-process" s-attr)))))))
        (defun ,(intern (format "kubernetes-%s-refresh-now" s-attr)) (&optional interactive)
+         (interactive "p")
          (kubernetes-kubectl-await
           (apply-partially #'kubernetes-kubectl
                            kubernetes-props

--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -391,6 +391,44 @@
 
 ;; State accessors
 
+(defmacro kubernetes-state-define-refreshers (attr &optional canned raw)
+  (declare (indent 2))
+  (let* ((s-attr (symbol-name attr))
+         (canned (or canned (intern (format "kubernetes-kubectl-get-%s" s-attr)))))
+    `(progn
+       (defun ,(intern (format "kubernetes-%s-refresh" s-attr)) (&optional interactive)
+         (unless (,(intern (format "kubernetes-process-poll-%s-process-live-p" s-attr)))
+           (,(intern (format "kubernetes-process-set-poll-%s-process" s-attr))
+            (,canned
+             kubernetes-props
+             (kubernetes-state)
+             (lambda (response)
+               (,(intern (format "kubernetes-state-update-%s" s-attr)) response)
+               (when interactive
+                 (message (concat "Updated " ,s-attr "."))))
+             (function
+              ,(intern (format "kubernetes-process-release-poll-%s-process" s-attr)))))))
+       (defun ,(intern (format "kubernetes-%s-refresh-now" s-attr)) (&optional interactive)
+         (kubernetes-kubectl-await
+          (apply-partially #'kubernetes-kubectl
+                           kubernetes-props
+                           (kubernetes-state)
+                           ',(if raw (split-string raw) (list "get" s-attr "-o" "json")))
+          (lambda (buf)
+            (with-current-buffer buf
+              (when interactive
+                (message (concat "Updated " ,s-attr ".")))
+              (,(intern (format "kubernetes-state-update-%s" s-attr))
+               (json-read-from-string (buffer-string)))
+              (-let* (((&alist 'items)
+                       (,(intern (format "kubernetes-state-%s" s-attr))
+                        (kubernetes-state))))
+                (seq-map (lambda (item)
+                           (-let* (((&alist 'metadata (&alist 'name)) item)) name))
+                         items))))
+          nil
+          #'ignore)))))
+
 (defmacro kubernetes-state--define-getter (attr)
   `(defun ,(intern (format "kubernetes-state-%s" attr)) (state)
      (alist-get (quote ,attr) state)))

--- a/kubernetes-statefulsets.el
+++ b/kubernetes-statefulsets.el
@@ -127,17 +127,7 @@
 
 ;; Requests and state management
 
-(defun kubernetes-statefulsets-refresh (&optional interactive)
-  (unless (kubernetes-process-poll-statefulsets-process-live-p)
-    (kubernetes-process-set-poll-statefulsets-process
-     (kubernetes-kubectl-get-statefulsets kubernetes-props
-                                         (kubernetes-state)
-                                         (lambda (response)
-                                           (kubernetes-state-update-statefulsets response)
-                                           (when interactive
-                                             (message "Updated statefulsets.")))
-                                         (lambda ()
-                                           (kubernetes-process-release-poll-statefulsets-process))))))
+(kubernetes-state-define-refreshers statefulsets)
 
 (defun kubernetes-statefulsets-delete-marked (state)
   (let ((names (kubernetes-state-marked-statefulsets state)))

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -1,4 +1,4 @@
-;deployments;; kubernetes-utils.el --- Common utilities.  -*- lexical-binding: t; -*-
+;; kubernetes-utils.el --- Common utilities.  -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Code:
 

--- a/kubernetes-utils.el
+++ b/kubernetes-utils.el
@@ -15,22 +15,8 @@
 
 (autoload 'org-read-date "org")
 
-(defun kubernetes-utils-read-pod-name (state)
-  "Read a pod name from the user.
-
-STATE is the current application state.
-
-Update the pod state if it not set yet."
-  (-let* (((&alist 'items pods)
-           (or (kubernetes-state-pods state)
-               (progn
-                 (message "Getting pods...")
-                 (let ((response (kubernetes-kubectl-await-on-async kubernetes-props state #'kubernetes-kubectl-get-pods)))
-                   (kubernetes-state-update-pods response)
-                   response))))
-          (pods (append pods nil))
-          (names (-map #'kubernetes-state-resource-name pods)))
-    (completing-read "Pod: " names nil t)))
+(defalias 'kubernetes-utils-read-pod-name 'kubernetes-pods--read-name
+  "Exporting `kubernetes-pods--read-name'")
 
 (defun kubernetes-utils-read-iso-datetime (&rest _)
   (let* ((date (org-read-date nil t))

--- a/test/kubernetes-state-test.el
+++ b/test/kubernetes-state-test.el
@@ -6,7 +6,6 @@
 (require 'kubernetes-state)
 (declare-function test-helper-json-resource "test-helper.el")
 
-
 ;; Sample responses.
 
 (defconst sample-get-pods-response
@@ -32,7 +31,6 @@
 
 (defconst sample-get-config-response
   (test-helper-json-resource "config-view-response.json"))
-
 
 ;; Updating sets the main state
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -50,5 +50,4 @@
          (kubernetes-kubectl-flags))
      ,@body))
 
-
 ;;; test-helper.el ends here


### PR DESCRIPTION
Calling `kubernetes-pods-refresh` and querying `kubernetes-state-pods` does not guarantee seeing refreshed pods.

Preserved the old behavior of `kubernetes-*resource*-refresh`, and added `kubernetes-*resource*-refresh-now` that is synchronous, i.e., guarantees state is updated.