### PR TITLE
Travis CI coverage for Emacs 27

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,39 @@ jobs:
   include:
     - os: linux
       dist: bionic
-      env: EMACS_CI=emacs-25-1
+      env:
+        - JOB=2
+        - EMACS_CI=emacs-25-2
     - os: linux
       dist: bionic
-      env: EMACS_CI=emacs-25-2
+      env:
+        - JOB=3
+        - EMACS_CI=emacs-25-3
     - os: linux
       dist: bionic
-      env: EMACS_CI=emacs-25-3
+      env:
+        - JOB=4
+        - EMACS_CI=emacs-26-1
     - os: linux
       dist: bionic
-      env: EMACS_CI=emacs-26-1
+      env:
+        - JOB=5
+        - EMACS_CI=emacs-26-2
     - os: linux
       dist: bionic
-      env: EMACS_CI=emacs-26-2
+      env:
+        - JOB=6
+        - EMACS_CI=emacs-26-3
     - os: linux
       dist: bionic
-      env: EMACS_CI=emacs-26-3
+      env:
+        - JOB=7
+        - EMACS_CI=emacs-27-1
     - os: linux
       dist: bionic
-      env: EMACS_CI=emacs-27-1
-    - os: linux
-      dist: bionic
-      env: EMACS_CI=emacs-snapshot
+      env:
+        - JOB=8
+        - EMACS_CI=emacs-snapshot
 
 before_install:
   - sudo mkdir -p /etc/nix
@@ -40,18 +51,25 @@ before_cache:
   - mkdir -p $HOME/nix.store
   - nix copy --to file://$HOME/nix.store -f default.nix buildInputs
 
+before_script:
+  - sudo mkdir -p /etc/nix && echo 'sandbox = true' | sudo tee /etc/nix/nix.conf
+
 install:
+  - sleep $(((JOB - 1) * 10))
   # The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI
   - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
   - travis_retry eval $"curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python ; sleep 10"
   - export PATH=$HOME/.cask/bin:$PATH
-  - travis_retry eval $"cask install ; sleep 10"
+  - cask clean-elc --verbose
+  - travis_retry eval $"cask install --verbose ; sleep 10"
+  - travis_retry eval $"cask update --verbose ; sleep 10"
+  - travis_retry eval $"cask upgrade --verbose ; sleep 10"
   - nix-env -i kubectl
 
 script:
   - export PATH=$HOME/.cask/bin:$PATH
   - emacs --version
-  - cask build
+  - cask build --verbose
   - make build
   - make test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,61 @@
-language: emacs-lisp
+# https://github.com/purcell/nix-emacs-ci
+language: nix
+cache:
+  directories:
+  - $HOME/nix.store
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: EVM_EMACS=emacs-git-snapshot-travis-linux-trusty
+jobs:
   include:
     - os: linux
-      dist: trusty
-      env: EVM_EMACS=emacs-26.3-travis
+      dist: bionic
+      env: EMACS_CI=emacs-25-1
     - os: linux
-      dist: trusty
-      env: EVM_EMACS=emacs-git-snapshot-travis-linux-trusty
+      dist: bionic
+      env: EMACS_CI=emacs-25-2
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-25-3
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-26-1
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-26-2
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-26-3
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-27-1
+    - os: linux
+      dist: bionic
+      env: EMACS_CI=emacs-snapshot
 
 before_install:
-  - curl -fsSkL https://raw.github.com/rejeep/evm/master/go | bash
-  - export PATH=$HOME/.evm/bin:$HOME/.cask/bin:$PATH
-  - evm config path /tmp
-  - evm install $EVM_EMACS --use --skip
-  - curl -fsSkL https://raw.github.com/cask/cask/master/go | python
+  - sudo mkdir -p /etc/nix
+  - echo "substituters = https://cache.nixos.org/ file://$HOME/nix.store" | sudo tee -a /etc/nix/nix.conf > /dev/null
+  - echo 'require-sigs = false' | sudo tee -a /etc/nix/nix.conf > /dev/null
+
+before_cache:
+  - mkdir -p $HOME/nix.store
+  - nix copy --to file://$HOME/nix.store -f default.nix buildInputs
 
 install:
-  - cask install
+  # The default "emacs" executable on the $PATH will now be the version named by $EMACS_CI
+  - bash <(curl https://raw.githubusercontent.com/purcell/nix-emacs-ci/master/travis-install)
+  - travis_retry eval $"curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python ; sleep 10"
+  - export PATH=$HOME/.cask/bin:$PATH
+  - travis_retry eval $"cask install ; sleep 10"
+  - nix-env -i kubectl
 
 script:
+  - export PATH=$HOME/.cask/bin:$PATH
+  - emacs --version
+  - cask build
+  - make build
   - make test
+
+allow_failures:
+  - os: linux
+    dist: bionic
+    env: EMACS_CI=emacs-snapshot

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # https://github.com/purcell/nix-emacs-ci
+# https://nixos.wiki/wiki/Nix_on_Travis
 language: nix
 cache:
   directories:

--- a/Cask
+++ b/Cask
@@ -3,6 +3,7 @@
 (package-file "kubernetes.el")
 
 (development
+ (depends-on "undo-tree")
  (depends-on "undercover")
  (depends-on "evil")
  (depends-on "noflet")

--- a/Cask
+++ b/Cask
@@ -7,4 +7,5 @@
  (depends-on "evil")
  (depends-on "noflet")
  (depends-on "ert-runner")
+ (depends-on "dash")
  (depends-on "f"))

--- a/kubernetes-loading-container.el
+++ b/kubernetes-loading-container.el
@@ -15,7 +15,11 @@
   (cond
    ((null vector)
     on-loading)
-   ((and vector (seq-contains vector elem))
+   ((and vector
+         (if
+             (fboundp 'seq-contains-p)
+             (seq-contains-p vector elem)
+           (with-no-warnings (seq-contains vector elem))))
     on-found)
    (t
     on-not-found)))


### PR DESCRIPTION
Converts Travis CI to Nix.
Needs `kubectl` installed with Nix to fix a test: https://travis-ci.com/github/peterbecich/kubernetes-el/jobs/376627133#L6520