### PR TITLE
Pods: Display all containers

### DIFF
--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -29,11 +29,8 @@
                                   'podIP pod-ip
                                   'startTime start-time))
           pod)
-         ([(&alist 'image image 'name name)]
-          (or containers
-              (make-vector 1 (list '(name . "N/A") '(image . "N/A"))))))
-    `(,(funcall detail "Name" name)
-      ,(when label-name
+         (_containers (or containers (make-vector 0 '()))))
+    `(,(when label-name
          `(section (selector nil)
                    (nav-prop (:selector ,label-name)
                              ,(funcall detail "Label" (propertize label-name 'face 'kubernetes-selector)))))
@@ -41,10 +38,14 @@
          `(section (namespace nil)
                    (nav-prop (:namespace-name ,ns)
                              (key-value 12 "Namespace" ,(propertize ns 'face 'kubernetes-namespace)))))
-      ,(funcall detail "Image" image)
       ,(funcall detail "Host IP" host-ip)
       ,(funcall detail "Pod IP" pod-ip)
-      ,(funcall detail "Started" start-time))))
+      ,(funcall detail "Started" start-time)
+      (header-with-count "Containers:" ,_containers)
+      ,(cons 'list (-map (-lambda ((&alist 'image image 'name name))
+                           `((key-value 10 "Name" ,name)
+                             (key-value 10 "Image" ,image)))
+                         _containers)))))
 
 
 (kubernetes-ast-define-component pod-view-line (state pod)

--- a/test/kubernetes-pods-test.el
+++ b/test/kubernetes-pods-test.el
@@ -64,31 +64,34 @@ Pods (0)
 Pods (3)
   Name                                          Status     Ready   Restarts    Age
   example-svc-v3-1603416598-2f9lb               Running      1/1          0    36d
-    Name:       example-service-2
     Label:      example-pod-v3
     Namespace:  ns.example
-    Image:      example.com/example-service:3.0.0
     Host IP:    10.0.0.0
     Pod IP:     172.0.0.1
     Started:    2017-02-25T08:12:14Z
+    Containers: (1)
+    - Name:     example-service-2
+      Image:    example.com/example-service:3.0.0
 
-  example-svc-v4-1603416598-2f9lb               Running      1/1          0    36d
-    Name:       example-service-4
+  example-svc-v4-1603416598-2f9lb               Running      2/2          0    36d
     Label:      example-pod-v4
     Namespace:  ns.example
-    Image:      example.com/example-service:4.8.0
     Host IP:    10.0.0.0
     Pod IP:     172.0.0.1
     Started:    2017-02-25T08:12:14Z
+    Containers: (2)
+    - Name:     example-service-4
+      Image:    example.com/example-service:4.8.0
+    - Name:     fake-runner-0
+      Image:    fake.com/fake-runner:1.0.0
 
   example-svc-v5-1603416598-2f9lb               Running      0/0          0    36d
-    Name:       N/A
     Label:      example-pod-v5
     Namespace:  ns.example
-    Image:      N/A
     Host IP:    10.0.0.0
     Pod IP:     172.0.0.1
     Started:    2017-02-25T08:12:14Z
+    Containers: (0)
 
 
 "))

--- a/test/resources/get-pods-response.json
+++ b/test/resources/get-pods-response.json
@@ -393,6 +393,20 @@
                 "startedAt": "2017-02-25T08:13:39Z"
               }
             }
+          },
+          {
+            "containerID": "docker://fake-container-id",
+            "image": "fake.com/fake-runner:1.0.0",
+            "imageID": "docker-pullable://fake.com/fake-runner@sha256:2406309063027f398037b69c3cfcb2e108213f45c47998d26eedaf16d8253871",
+            "lastState": {},
+            "name": "fake-runner-0",
+            "ready": true,
+            "restartCount": 0,
+            "state": {
+              "running": {
+                "startedAt": "2017-02-25T08:13:39Z"
+              }
+            }
           }
         ],
         "hostIP": "10.0.0.0",


### PR DESCRIPTION
Closes #133.

Currently the `pod-view-detail` AST component is implemented to only show the
name and image of the first container that appears in `containerStatuses`. This
results in misleading display of pod details for pods running multiple
containers, as only one container's name and image are displayed:

```
POD_NAME                  Running      2/2          0    10d
  Name:       CONTAINER_0_NAME
  Namespace:  kubeflow
  Image:      CONTAINER_0_IMAGE
  Host IP:    10.202.56.91
  Pod IP:     10.202.78.194
  Started:    2021-04-29T12:26:05Z
```

This PR updates the `pod-view-detail` AST component to display all containers
for a given pod in enumerated list form, like so:

```
POD_NAME                  Running      2/2          0    10d
  Namespace:  kubeflow
  Host IP:    10.202.56.91
  Pod IP:     10.202.78.194
  Started:    2021-04-29T12:26:05Z
  Containers: (2)
    - Name:   CONTAINER_0_NAME
      Image:  CONTAINER_0_IMAGE
    - Name:   CONTAINER_1_NAME
      Image:  CONTAINER_1_IMAGE
```

Container-less pods are displayed like so:

```
POD_NAME                  Running      0/0          0    10d
  Namespace:  kubeflow
  Host IP:    10.202.56.91
  Pod IP:     10.202.78.194
  Started:    2021-04-29T12:26:05Z
  Containers: (0)
```