### PR TITLE
AST: Properly render lists w/ dash-prefixed elements

### DIFF
--- a/kubernetes-ast.el
+++ b/kubernetes-ast.el
@@ -131,7 +131,7 @@ such in rendering ASTs." name)))
     (goto-char start-pos)
     (goto-char (line-beginning-position))
     (skip-chars-forward " ")
-    (unless (eq (char-after) ?-)
+    (unless (string-equal "- " (buffer-substring (point) (+ 2 (point))))
       (delete-char -2)
       (insert "- "))))
 

--- a/kubernetes-yaml.el
+++ b/kubernetes-yaml.el
@@ -26,7 +26,7 @@
 
     ((pred vectorp)
      `(list ,@(seq-map (lambda (it)
-                         `(section (item nil) ,(kubernetes-yaml--render-helper it)))
+                         `(line ,(kubernetes-yaml--render-helper it)))
                        json)))
 
     ;; Objects

--- a/kubernetes-yaml.el
+++ b/kubernetes-yaml.el
@@ -26,7 +26,7 @@
 
     ((pred vectorp)
      `(list ,@(seq-map (lambda (it)
-                         `(line ,(kubernetes-yaml--render-helper it)))
+                         `(section (item nil) (line ,(kubernetes-yaml--render-helper it))))
                        json)))
 
     ;; Objects

--- a/test/kubernetes-ast-test.el
+++ b/test/kubernetes-ast-test.el
@@ -44,6 +44,17 @@
 
 ;; list
 
+(ert-deftest kubernetes-ast-list--list-with-dashes ()
+  (let ((ast '(list (line "foo") (line "-bar") (line "--baz")))
+        (expected (string-trim-left "
+- foo
+- -bar
+- --baz
+")))
+    (with-temp-buffer
+      (kubernetes-ast-eval ast)
+      (should (equal expected (buffer-string))))))
+
 (ert-deftest kubernetes-ast-test--lists ()
   (let ((ast '(list (line "foo") (line "bar") (line "baz")))
         (expected (string-trim-left "

--- a/test/kubernetes-yaml-test.el
+++ b/test/kubernetes-yaml-test.el
@@ -1,0 +1,30 @@
+;;; kubernetes-yaml-test.el --- Test rendering of YAML in general -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(ert-deftest kubernetes-yaml-test--yaml-render ()
+  (let* ((json "{\"args\": [\"--foo\", \"--bar\"], \"more\": 1}")
+         (parsed-json (json-read-from-string json)))
+    (with-temp-buffer
+      (save-excursion (kubernetes-ast-eval (kubernetes-yaml-render
+                                            parsed-json)))
+      ;; white space at end of line is deliberate
+      (should (equal "args: 
+  - --foo
+  - --bar
+more: 1
+
+" (buffer-string))))))
+
+(ert-deftest kubernetes-yaml-test--yaml-render--list ()
+  (let* ((json "[\"--foo\", \"--bar\"]")
+         (parsed-json (json-read-from-string json))
+         (rendered (kubernetes-yaml-render parsed-json)))
+    (with-temp-buffer
+      (save-excursion (kubernetes-ast-eval rendered))
+      (should (equal "- --foo
+- --bar
+
+" (buffer-string))))))
+
+;;; kubernetes-yaml-test.el ends here


### PR DESCRIPTION
Closes #81.

Current AST rendering logic for bullet lists was such that lists that
we expect to be rendered like so:
```yaml
args:
  - --foo
  - --bar
  - --baz
```

Were instead getting rendered along the lines of the following:
```yaml
args:
  --foo--bar--baz
```

This PR fixes rendering of bullet lists to align with the former
output.

Incidentally, we also fix up a related bug in list rendering that
results in the following expected output:
```yaml
- foo
- -bar
- --baz
```

Instead getting rendered like so:
```yaml
- foo
-bar
--baz
```

Both of these scenarios can be confirmed by checking out the
contributed test cases, less the changes to
`kubernetes-{ast,yaml}.el`, and running them on `master`.