### PR TITLE
Rename variable to satisfy byte compiler

### DIFF
--- a/kubernetes-pods.el
+++ b/kubernetes-pods.el
@@ -29,7 +29,7 @@
                                   'podIP pod-ip
                                   'startTime start-time))
           pod)
-         (_containers (or containers (make-vector 0 '()))))
+         (containers (or containers (make-vector 0 '()))))
     `(,(when label-name
          `(section (selector nil)
                    (nav-prop (:selector ,label-name)
@@ -41,11 +41,11 @@
       ,(funcall detail "Host IP" host-ip)
       ,(funcall detail "Pod IP" pod-ip)
       ,(funcall detail "Started" start-time)
-      (header-with-count "Containers:" ,_containers)
+      (header-with-count "Containers:" ,containers)
       ,(cons 'list (-map (-lambda ((&alist 'image image 'name name))
                            `((key-value 10 "Name" ,name)
                              (key-value 10 "Image" ,image)))
-                         _containers)))))
+                         containers)))))
 
 
 (kubernetes-ast-define-component pod-view-line (state pod)


### PR DESCRIPTION
CI is failing currently due to the following:
```
kubernetes-pods.el:22:1:Error: variable `_containers' not left unused
```

[Elisp
documentation](https://www.gnu.org/software/emacs/manual/html_mono/elisp.html#Using-Lexical-Binding)
points out that underscores should be used only for variables known
not to be used, so we rename the variable used here.