### PR TITLE
Add command to kill all k8s buffers at once

### DIFF
--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -8,6 +8,7 @@
 (require 'kubernetes-props)
 (require 'kubernetes-state)
 (require 'kubernetes-utils)
+(require 'mode-local)
 
 (autoload 'kubernetes-configmaps-delete-marked "kubernetes-configmaps")
 (autoload 'kubernetes-deployments-delete-marked "kubernetes-deployments")
@@ -144,6 +145,24 @@
 
 
 ;; Misc commands
+
+;;;###autoload
+(defun kubernetes-kill-buffers ()
+  "Kill all `kubernetes-mode' buffers."
+  (interactive)
+  (let* ((kubernetes-buffer-p
+          (lambda (buffer)
+            (let ((major-mode (buffer-local-value 'major-mode buffer)))
+              (or (eq major-mode 'kubernetes-mode)
+                  (eq (get-mode-local-parent major-mode) 'kubernetes-mode)))))
+         (buffers (-filter kubernetes-buffer-p (buffer-list)))
+         (num-buffers (length buffers)))
+    (if (not buffers)
+        (message "No Kubernetes buffers to kill.")
+      (when (y-or-n-p (format "Kill %s Kubernetes buffer(s)? " num-buffers))
+        (dolist (buffer buffers)
+          (kill-buffer buffer))
+        (message "Killed %s Kubernetes buffers." num-buffers)))))
 
 ;;;###autoload
 (defun kubernetes-copy-thing-at-point (point)

--- a/kubernetes-commands.el
+++ b/kubernetes-commands.el
@@ -147,9 +147,12 @@
 ;; Misc commands
 
 ;;;###autoload
-(defun kubernetes-kill-buffers ()
-  "Kill all `kubernetes-mode' buffers."
-  (interactive)
+(defun kubernetes-kill-buffers (&optional no-confirm)
+  "Kill all `kubernetes-mode' buffers.
+
+With prefix argument, skips confirmation prior to killing all
+buffers."
+  (interactive "P")
   (let* ((kubernetes-buffer-p
           (lambda (buffer)
             (let ((major-mode (buffer-local-value 'major-mode buffer)))
@@ -159,7 +162,7 @@
          (num-buffers (length buffers)))
     (if (not buffers)
         (message "No Kubernetes buffers to kill.")
-      (when (y-or-n-p (format "Kill %s Kubernetes buffer(s)? " num-buffers))
+      (when (or no-confirm (y-or-n-p (format "Kill %s Kubernetes buffer(s)? " num-buffers)))
         (dolist (buffer buffers)
           (kill-buffer buffer))
         (message "Killed %s Kubernetes buffers." num-buffers)))))

--- a/kubernetes-modes.el
+++ b/kubernetes-modes.el
@@ -6,6 +6,7 @@
 (require 'subr-x)
 
 (autoload 'kubernetes-config-popup "kubernetes-popups")
+(autoload 'kubernetes-kill-buffers "kubernetes-commands")
 (autoload 'kubernetes-copy-thing-at-point "kubernetes-commands")
 (autoload 'kubernetes-describe-popup "kubernetes-popups")
 (autoload 'kubernetes-exec-popup "kubernetes-popups")
@@ -42,6 +43,7 @@
     (define-key keymap [S-tab]     #'magit-section-cycle-global)
     ;; Misc
     (define-key keymap (kbd "q") #'quit-window)
+    (define-key keymap (kbd "Q") #'kubernetes-kill-buffers)
     (define-key keymap (kbd "RET") #'kubernetes-navigate)
     (define-key keymap (kbd "M-w") #'kubernetes-copy-thing-at-point)
     (define-key keymap (kbd "h") #'describe-mode)

--- a/test/kubernetes-commands-test.el
+++ b/test/kubernetes-commands-test.el
@@ -1,0 +1,23 @@
+;;; kubernetes-commands-test.el --- Test interactive commands -*- lexical-binding: t; -*-
+;;; Commentary:
+;;; Code:
+
+(defun make-buffer-with-mode (name mode)
+  "Make buffer named NAME with major mode MODE."
+  (with-current-buffer (get-buffer-create name)
+    (funcall mode)))
+
+(ert-deftest kubernetes-commands--kubernetes-kill-buffers ()
+  (let ((buffers-modes '(("foo" kubernetes-mode)
+                         ("bar" kubernetes-overview-mode)
+                         ("baz" kubernetes-log-line-mode))))
+    (dolist (buffer-mode buffers-modes)
+      (apply #'make-buffer-with-mode buffer-mode))
+    (cl-letf (((symbol-function 'message) 'ignore)
+              ((symbol-function 'y-or-n-p) (lambda (&rest _) t)))
+      (kubernetes-kill-buffers))
+    (-map (lambda (buffer-mode)
+            (should (equal nil (get-buffer (car buffer-mode)))))
+          buffers-modes)))
+
+;;; kubernetes-commands-test.el ends here


### PR DESCRIPTION
Closes #142.

This PR provides a command, `kubernetes-kill-buffers`, that kills every `kubernetes` buffer, doing so by selecting all buffers whose major mode derives from `kubernetes-mode`. It also provides a rudimentary unit test for the new behavior.

This function is inspired largely by [`helpful-kill-buffers`](https://github.com/Wilfred/helpful/blob/master/helpful.el#L2845) from the [`helpful` package](https://github.com/Wilfred/helpful). This implementation expands on the inspiration with both pre- and post-kill confirmation.