### PR TITLE
Migrate code coverage tracking to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,3 +53,14 @@ jobs:
         if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
         run: |
           make test
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+          COVERALLS_PARALLEL: 1
+          COVERALLS_FLAG_NAME: Emacs ${{ matrix.emacs_version }}
+
+  finish:
+    needs: build-and-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl "https://coveralls.io/webhook?repo_name=$GITHUB_REPOSITORY&repo_token=${{ secrets.GITHUB_TOKEN }}" -d "payload[build_num]=$GITHUB_RUN_NUMBER&payload[status]=done"


### PR DESCRIPTION
The move towards GitHub Actions for CI in #146 removed code coverage
tracking via Coveralls, which until now had come "for free" via
Travis.

This PR reintroduces Coveralls tracking via the guidance in
[undercover](https://github.com/undercover-el/undercover.el)
documentation. Unfortunately, this only enables tracking, but does not
provide feedback in PR of changes to test coverage like before. Were
undercover to integrate LCOV reporting support (see
undercover-el/undercover.el#68), this could then move to using [the
official Coveralls GitHub
Action](https://github.com/marketplace/actions/coveralls-github-action),
which would give that reporting.