### PR TITLE
CI: Report coverage using Coveralls GitHub Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,14 +53,21 @@ jobs:
         if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
         run: |
           make test
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-          COVERALLS_PARALLEL: 1
-          COVERALLS_FLAG_NAME: Emacs ${{ matrix.emacs_version }}
+
+      - name: Coveralls
+        if: steps.install.outcome == 'success' && steps.install.conclusion == 'success'
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          flag-name: emacs-${{ matrix.emacs_version }}
+          parallel: true
 
   finish:
     needs: build-and-test
-    if: always()
     runs-on: ubuntu-latest
     steps:
-      - run: curl "https://coveralls.io/webhook?repo_name=$GITHUB_REPOSITORY&repo_token=${{ secrets.GITHUB_TOKEN }}" -d "payload[build_num]=$GITHUB_RUN_NUMBER&payload[status]=done"
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/Cask
+++ b/Cask
@@ -4,7 +4,7 @@
 
 (development
  (depends-on "undo-tree")
- (depends-on "undercover")
+ (depends-on "undercover" "0.8.1")
  (depends-on "evil")
  (depends-on "noflet")
  (depends-on "ert-runner")

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -18,7 +18,11 @@
 
 (when (require 'undercover nil t)
   (with-no-warnings
-    (undercover "*.el" (:exclude "kubernetes-evil.el"))))
+    (undercover "*.el"
+                (:exclude "kubernetes-evil.el")
+                (:merge-report nil)
+                (:report-format 'lcov)
+                (:send-report nil))))
 
 
 ;; Load package


### PR DESCRIPTION
Now that `undercover` is compatible with the official [Coveralls GitHub Action](https://github.com/marketplace/actions/coveralls-github-action) (see undercover-el/undercover.el#68), this PR updates CI to use the official Action for in-PR coverage change reporting etc.