### PR TITLE
Deps: Remove undo-tree

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,7 +3,6 @@
 (package-file "kubernetes.el")
 
 (development
- (depends-on "undo-tree")
  (depends-on "undercover" "0.8.1")
  (depends-on "evil")
  (depends-on "noflet")


### PR DESCRIPTION
It's unclear to me why the `undo-tree` dependency was introduced in #127 -- nor does it seem used anywhere in the codebase -- so we remove it here.

@noorul + other contributors: let me know if I'm mistaken and the dependency is actually necessary.