### PR TITLE
k8s-state: update-last-error: Fix non-fatal syntax error

### DIFF
--- a/kubernetes-state.el
+++ b/kubernetes-state.el
@@ -563,7 +563,7 @@
   (cl-assert (-all? #'integerp time))
   (let ((arg `((message . ,message)
                (command . ,command)
-               (time ., time))))
+               (time . ,time))))
     (kubernetes-state-update :update-last-error arg)
     arg))
 


### PR DESCRIPTION
`undercover` fails to parse this particular line with the following
message:
```
UNDERCOVER: Error while loading /Users/jjin/dev/kubernetes-el/kubernetes-state.el for coverage:
UNDERCOVER: Invalid read syntax: "."
UNDERCOVER: The problem may be due to edebug failing to parse the file.
UNDERCOVER: You can try to narrow down the problem using the following steps:
UNDERCOVER: 1. Open "/Users/jjin/dev/kubernetes-el/kubernetes-state.el" in an Emacs buffer;
UNDERCOVER: 2. Run M-: ‘(require 'edebug)’;
UNDERCOVER: 3. Run M-x ‘edebug-all-defs’;
UNDERCOVER: 4. Run M-x ‘toggle-debug-on-error’.
UNDERCOVER: 5. Run M-x ‘eval-buffer’;
UNDERCOVER: 6. In the *Backtrace* buffer, find a numeric position,
UNDERCOVER:    then M-x ‘goto-char’ to it.
```

We can reproduce this w/ `edebug-defun` on the definition.

As it turns out, substitution with `,` in a backquoted list runs "just
fine" if the comma is not attached to the element to expand, as we can
reproduce here:
```emacs-lisp
(let ((foo t))
  `(, foo))
```

However, we fix up the definition for full correctness and so that
undercover doesn't complain.